### PR TITLE
Fixed typo in #spacer

### DIFF
--- a/FCC-ProductLanding.css
+++ b/FCC-ProductLanding.css
@@ -10,7 +10,7 @@
 
     #spacer {
         height: 180px;
-        position: block;
+        display: block;
     }
 
     .box {


### PR DESCRIPTION
Fixed typo in #spacer. position: block; --> display: block;